### PR TITLE
Removed deprecated visibility header and updated type assignment to command_interface.set_value()

### DIFF
--- a/franka_example_controllers/src/gravity_compensation_example_controller.cpp
+++ b/franka_example_controllers/src/gravity_compensation_example_controller.cpp
@@ -39,7 +39,7 @@ controller_interface::return_type GravityCompensationExampleController::update(
     const rclcpp::Time& /*time*/,
     const rclcpp::Duration& /*period*/) {
   for (auto& command_interface : command_interfaces_) {
-    command_interface.set_value(0);
+    command_interface.set_value(0.0);
   }
   return controller_interface::return_type::OK;
 }

--- a/franka_example_controllers/src/move_to_start_example_controller.cpp
+++ b/franka_example_controllers/src/move_to_start_example_controller.cpp
@@ -63,7 +63,7 @@ controller_interface::return_type MoveToStartExampleController::update(
     }
   } else {
     for (auto& command_interface : command_interfaces_) {
-      command_interface.set_value(0);
+      command_interface.set_value(0.0);
     }
     this->get_node()->set_parameter({"process_finished", true});
   }

--- a/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
+++ b/franka_hardware/include/franka_hardware/franka_hardware_interface.hpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <hardware_interface/visibility_control.h>
 #include <hardware_interface/hardware_info.hpp>
 #include <hardware_interface/system_interface.hpp>
 #include <hardware_interface/types/hardware_interface_return_values.hpp>


### PR DESCRIPTION
1. `visibility_control.h` from `ROS2_control` is removed in [4.23.0](https://github.com/ros-controls/ros2_control/commits/4.23.0/) release  (see PR https://github.com/ros-controls/ros2_control/pull/1972#issue-2756749235) this is mostly boiler plate code for generating libraries on Windows so removing this header shouldn't impact Linux.

2. `hardware_interface::HANDLE_DATATYPE`/`std::variant<std::monostate, double, bool>` expects either `double` or `bool`. Modifying `int` 0 to 0.0.

This should fix compilation errors on new systems.
